### PR TITLE
React bootstrap changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,13 +42,14 @@
     "rollup-plugin-commonjs": "^9.2.1",
     "rollup-plugin-uglify": "6.0.2",
     "typescript": "3.3.3333",
-    "@types/react": "^16.3.0"
+    "@types/react": "^16.3.0",
+    "@types/react-dom": "^16.9.1"
   },
   "peerDependencies": {
     "react": "^16.3.0"
   },
   "dependencies": {
     "smooth-dnd": "0.12.0",
-    "prop-types":">=15.6.0"
+    "prop-types": ">=15.6.0"
   }
 }

--- a/src/Container.tsx
+++ b/src/Container.tsx
@@ -1,4 +1,5 @@
 import React, { Component, CSSProperties } from 'react';
+import ReactDOM from 'react-dom'
 import PropTypes from 'prop-types';
 import { smoothDnD as container, ContainerOptions, SmoothDnD } from 'smooth-dnd';
 import { dropHandlers } from 'smooth-dnd';
@@ -64,7 +65,8 @@ class Container extends Component<ContainerProps> {
 
   componentDidMount() {
     this.prevContainer = this.getContainer();
-    this.container = container(this.getContainer(), this.getContainerOptions());
+    var __container = ReactDOM.findDOMNode(this.getContainer());
+    this.container = container(__container || this.getContainer(), this.getContainerOptions());
   }
 
   componentWillUnmount() {

--- a/src/Draggable.tsx
+++ b/src/Draggable.tsx
@@ -18,7 +18,7 @@ class Draggable extends Component<DraggableProps> {
 
 	render() {
 		if (this.props.render) {
-			return React.cloneElement(this.props.render(), { className: wrapperClass });
+			return React.cloneElement(this.props.render(), { className: `${this.props.className} ${wrapperClass}` });
 		}
 		
 		const clsName = `${this.props.className ? (this.props.className + ' ') : ''}`


### PR DESCRIPTION
I've been using your library to implement drag and drop server tabs for https://github.com/mattermost/desktop. We're using the `Nav` component from `react-bootstrap` and I ran into a couple issues when working with this library.

**1) Need to be able to apply a base class when wrapping `Draggable` with a `render()` function:**
I noticed that when supplying my own `render()` function to the `Draggable` component that my `className` was getting overwritten by the default `wrapperClass`. My change adds the `className` prop already built into `Draggable` to the `React.cloneElement()` function so that both `classNames` are included in the finally rendered element.

**2) Need to be to supply React components as `render()` results when wrapping with `Container`:**
When I supplied the `render()` function to `Container` where the result was a `Nav` component from `react-bootstrap`, I got a white screen from React. I noticed that your original library expected an `HTMLElement`, which makes perfect sense, but the `Container` wrapper passed the exact output of `render()` which was a `React.Component`. My change finds the actual `HTMLElement` if it exists and passes that to the `container()` function, such that it will always be an `HTMLElement`.

Let me know your thoughts on these changes and if you think they would be helpful to this project :). I welcome any suggestions!