### PR TITLE
Allow className in Draggable to be set when defining the render function

### DIFF
--- a/src/Draggable.tsx
+++ b/src/Draggable.tsx
@@ -17,13 +17,15 @@ class Draggable extends Component<DraggableProps> {
 	}
 
 	render() {
+		const clsName = `${this.props.className ? (this.props.className + ' ') : ''}`
+		const fullClsName = `${clsName}${wrapperClass}`
+		
 		if (this.props.render) {
-			return React.cloneElement(this.props.render(), { className: wrapperClass });
+			return React.cloneElement(this.props.render(), { className: fullClsName });
 		}
 		
-		const clsName = `${this.props.className ? (this.props.className + ' ') : ''}`
 		return (
-			<div {...this.props} className={`${clsName}${wrapperClass}`} >
+			<div {...this.props} className={fullClsName} >
 				{this.props.children}
 			</div>
 		);


### PR DESCRIPTION
Without this it's impossible to specify the className when using the render function in Draggable (which I happened to need because I needed ref forwarding).

It's a pretty straightforward fix and shouldn't result in any negative side-effects for people