### PR TITLE
fix: prevent runtime error when component will unmount

### DIFF
--- a/src/Container.tsx
+++ b/src/Container.tsx
@@ -68,8 +68,10 @@ class Container extends Component<ContainerProps> {
   }
 
   componentWillUnmount() {
-    this.container.dispose();
-    this.container = null!;
+    if (this.container) {
+      this.container.dispose();
+      this.container = null!;
+    }
   }
 
   componentDidUpdate(prevProps: ContainerProps) {


### PR DESCRIPTION
This change will prevent a crash, when react calls the `componentWillUnmount` lifecycle method upon unmounting the `<Container>` component. Somehow we managed to reach a state, where `this.container` is already null thus throwing an error when trying to call `dispose()`.

> TypeError: Cannot read properties of null (reading 'dispose')

We are using react v18.2.0.